### PR TITLE
Chaptered structure + prose/code step rhythm

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,26 @@ mapped on a −5..+5 spectrum. The first book built on this format.
 - Wheel + touch swipe + keyboard nav
 - The [`sveltekitbook`](https://www.npmjs.com/package/sveltekitbook) runtime as a dependency
 
-**Continuum format** — the axis every page lives on:
+**Structure** — how sections are grouped:
+- **flat** (default) — one linear sequence of sections, page numbers run end-to-end
+- **chaptered** — sections grouped into chapters; reader gets a chapter rail, chapter intros, `[`/`]` keys to jump between chapters, and a chapter-grouped contents page. Page numbering stays linear across the whole book; chapters are derived from each section's `chapterId`. Mutually exclusive with timeline / spectrum continua.
+
+Chaptered sections can also use a `steps` array — a strict prose / code / prose / code rhythm, one step at a time:
+
+```js
+{
+  title: 'Push',
+  gesture: '...',
+  steps: [
+    { prose: 'First we mutate the list...', code: 'fn push(&mut self) { ... }', lang: 'rust' },
+    { prose: 'Then we hand back the new head...', code: '...', lang: 'rust' }
+  ]
+}
+```
+
+If `steps` is present, the renderer pairs each prose chunk with its code block in order. Use it for tutorials and code-led explainers.
+
+**Continuum format** — the axis every page lives on (flat structure only):
 - **none** — flat sequence, no viz
 - **timeline** — pages carry a `year`, rendered as dots on a decade axis
 - **spectrum** — pages carry a `spectrum` integer, rendered as colored dots across a −N..+N ramp with per-page palette shifts

--- a/bin/index.js
+++ b/bin/index.js
@@ -48,6 +48,16 @@ async function main() {
       },
       {
         type: 'select',
+        name: 'structure',
+        message: 'Structure',
+        choices: [
+          { title: 'Flat — one linear sequence of sections', value: 'flat' },
+          { title: 'Chaptered — sections grouped into chapters with chapter nav', value: 'chaptered' }
+        ],
+        initial: 0
+      },
+      {
+        type: (prev) => (prev === 'chaptered' ? null : 'select'),
         name: 'continuum',
         message: 'Continuum format',
         choices: [
@@ -99,7 +109,8 @@ async function main() {
     title: a.title || 'Untitled',
     author: a.author || '',
     githubRepo: a.githubRepo || '',
-    continuum: a.continuum,
+    structure: a.structure || 'flat',
+    continuum: a.structure === 'chaptered' ? 'none' : a.continuum,
     spectrumRange: a.spectrumRange || 0,
     rooms: a.rooms || []
   });

--- a/bin/scaffold.js
+++ b/bin/scaffold.js
@@ -60,11 +60,13 @@ function buildNavLinks(roomSet) {
  * @param {{
  *   dest: string, dir: string, title: string, author: string,
  *   githubRepo: string, continuum: 'none'|'timeline'|'spectrum',
- *   spectrumRange: number, rooms: string[]
+ *   spectrumRange: number, rooms: string[],
+ *   structure?: 'flat'|'chaptered'
  * }} answers
  */
 export function scaffold(answers) {
   const { dest, dir, title, author, githubRepo, continuum, spectrumRange } = answers;
+  const structure = answers.structure || 'flat';
 
   const rooms = new Set(answers.rooms || []);
   if (continuum === 'none') rooms.delete('continuum-page');
@@ -112,5 +114,8 @@ export function scaffold(answers) {
     } else {
       copyTree(path.join(TEMPLATES, 'rooms', room), dest, ctx);
     }
+  }
+  if (structure !== 'flat') {
+    copyTree(path.join(TEMPLATES, 'structure', structure), dest, ctx);
   }
 }

--- a/templates/structure/chaptered/src/lib/outline.js
+++ b/templates/structure/chaptered/src/lib/outline.js
@@ -1,0 +1,147 @@
+// Chaptered book. Sections are still linear (page numbers run end-to-end), but
+// each one carries the chapter it belongs to. Group consecutive same-`chapterId`
+// sections and you get the chapter list — no separate tree to maintain.
+
+const raw = [
+  {
+    chapterId: 'beginnings',
+    chapterNum: 1,
+    chapterTitle: 'Beginnings',
+    chapterIntro: 'A short opening chapter to set up the format. Each chapter starts with a one-line intro that renders above its first section.',
+    title: 'First section',
+    gesture: 'Open with the thing you want the reader to remember.',
+    body: 'Then explain it. Use **bold** for emphasis, *italic* sparingly. Cite sources. Link out freely.',
+    eli5: 'Plain-language version of the same point, so a reader with no background can follow.'
+  },
+  {
+    chapterId: 'beginnings',
+    chapterNum: 1,
+    chapterTitle: 'Beginnings',
+    title: 'Second section',
+    gesture: 'Each section gets a short hook — one sentence the reader could quote back.',
+    body: 'Sections within a chapter share `chapterId`. Keep them in reading order; chapters are derived from this array, not declared separately.'
+  },
+  {
+    chapterId: 'beginnings',
+    chapterNum: 1,
+    chapterTitle: 'Beginnings',
+    title: 'Third section',
+    gesture: 'A section without `eli5` just omits that block. Every optional field is optional.',
+    body: 'Write only what matters.'
+  },
+  {
+    chapterId: 'middles',
+    chapterNum: 2,
+    chapterTitle: 'Middles',
+    chapterIntro: 'A new `chapterId` opens the next chapter. Page numbers keep counting from where the previous chapter left off.',
+    title: 'Crossing over',
+    gesture: 'When the reader hits the first section of a new chapter, the chapter intro renders above the section title.',
+    body: 'Reaching this section, the reader sees a "Chapter 2 — Middles" header and the chapter intro before the section content.'
+  },
+  {
+    chapterId: 'middles',
+    chapterNum: 2,
+    chapterTitle: 'Middles',
+    title: 'Last section',
+    gesture: 'The bottom nav shows the next chapter when you reach the end of a chapter.',
+    body: 'Use the chapter rail at the top to jump between chapters. Use prev/next at the bottom to walk linearly.'
+  },
+  {
+    chapterId: 'middles',
+    chapterNum: 2,
+    chapterTitle: 'Middles',
+    title: 'Code-led section',
+    gesture: 'For tutorials and explainers, the `steps` field lets a section alternate prose and code in a strict rhythm.',
+    steps: [
+      {
+        prose: 'A step is one short prose paragraph followed by one code block. Steps render in order, prose-code-prose-code, no other ordering allowed.',
+        code: '// pseudo-code\nlet section = {\n  steps: [\n    { prose: "...", code: "...", lang: "rust" }\n  ]\n};',
+        lang: 'js'
+      },
+      {
+        prose: 'The next step explains what just happened, then shows the next thing. The reader\'s eye moves down the page in a predictable cadence.',
+        code: 'fn explain(step) {\n  render(step.prose);\n  render(step.code);\n}',
+        lang: 'rust'
+      },
+      {
+        prose: 'Use this when the code is the argument and prose is connective tissue. For prose-led sections, leave `steps` off and use `body` as before.',
+        code: '// flat list field, free-form prose\nbody: "longer essay-style text..."',
+        lang: 'js'
+      }
+    ]
+  }
+];
+
+export const flat = raw.map((s, i) => ({
+  ...s,
+  num: String(i + 1).padStart(2, '0'),
+  orderIndex: i
+}));
+
+function buildChapters(sections) {
+  const order = [];
+  const map = new Map();
+  for (const s of sections) {
+    if (!map.has(s.chapterId)) {
+      map.set(s.chapterId, {
+        id: s.chapterId,
+        num: s.chapterNum,
+        title: s.chapterTitle,
+        intro: s.chapterIntro || '',
+        sections: []
+      });
+      order.push(s.chapterId);
+    }
+    map.get(s.chapterId).sections.push(s);
+  }
+  return order.map((id) => map.get(id));
+}
+
+export const chapters = buildChapters(flat);
+
+export function next(num) {
+  const i = flat.findIndex((s) => s.num === num);
+  return i >= 0 && i < flat.length - 1 ? flat[i + 1] : null;
+}
+
+export function prev(num) {
+  const i = flat.findIndex((s) => s.num === num);
+  return i > 0 ? flat[i - 1] : null;
+}
+
+export function chapterOf(num) {
+  const s = flat.find((s) => s.num === num);
+  return s ? chapters.find((c) => c.id === s.chapterId) : null;
+}
+
+export function chapterIndexOf(num) {
+  const c = chapterOf(num);
+  return c ? chapters.indexOf(c) : -1;
+}
+
+export function nextChapter(num) {
+  const i = chapterIndexOf(num);
+  return i >= 0 && i < chapters.length - 1 ? chapters[i + 1] : null;
+}
+
+export function prevChapter(num) {
+  const i = chapterIndexOf(num);
+  return i > 0 ? chapters[i - 1] : null;
+}
+
+export function isFirstOfChapter(num) {
+  const c = chapterOf(num);
+  return c ? c.sections[0].num === num : false;
+}
+
+export function isLastOfChapter(num) {
+  const c = chapterOf(num);
+  return c ? c.sections[c.sections.length - 1].num === num : false;
+}
+
+export function positionInChapter(num) {
+  const c = chapterOf(num);
+  if (!c) return null;
+  const i = c.sections.findIndex((s) => s.num === num);
+  return { index: i, total: c.sections.length };
+}

--- a/templates/structure/chaptered/src/routes/+page.svelte
+++ b/templates/structure/chaptered/src/routes/+page.svelte
@@ -1,0 +1,147 @@
+<script>
+  import { goto } from '$app/navigation';
+  import { base } from '$app/paths';
+  import { flat, chapters } from '$lib/outline.js';
+  import { createPager } from 'sveltekitbook/gestures';
+  import { TITLE, AUTHOR, YEAR } from '$lib/config.js';
+
+  let dragOffset = $state(0);
+  let dragging = $derived(dragOffset !== 0);
+
+  function start() {
+    goto(base + '/' + flat[0].num);
+  }
+
+  const pager = createPager({
+    onNext: start,
+    onPrev: () => {},
+    setOffset: (v) => {
+      dragOffset = Math.min(0, v);
+    }
+  });
+
+  function key(e) {
+    if (e.key === 'Enter' || e.key === 'ArrowRight' || e.key === ' ') start();
+  }
+</script>
+
+<svelte:window onkeydown={key} />
+
+<main
+  class="cover"
+  class:dragging
+  onwheel={pager.onWheel}
+  ontouchstart={pager.onTouchStart}
+  ontouchmove={pager.onTouchMove}
+  ontouchend={pager.onTouchEnd}
+  ontouchcancel={pager.onTouchCancel}
+  style:transform="translateX({dragOffset}px)"
+>
+  <div class="meta top">
+    <span>{AUTHOR ? `${AUTHOR} · ` : ''}{YEAR}</span>
+  </div>
+
+  <div class="title-block">
+    <h1 class="vt-title">{TITLE}</h1>
+    <p class="sub">{chapters.length} {chapters.length === 1 ? 'chapter' : 'chapters'} · {flat.length} sections.</p>
+  </div>
+
+  <div class="meta bottom">
+    <button onclick={start}>Begin&nbsp;→</button>
+    <nav class="cover-nav">
+      {{navLinks}}
+    </nav>
+    <span class="hint">Enter, arrow, swipe, or scroll · [ ] for chapter</span>
+  </div>
+</main>
+
+<style>
+  .cover {
+    position: relative;
+    height: 100vh;
+    height: 100dvh;
+    padding: 5vw 7vw;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    transition: transform 320ms cubic-bezier(0.2, 0.9, 0.3, 1);
+    touch-action: pan-y;
+    will-change: transform;
+  }
+
+  .cover.dragging { transition: none; }
+
+  .meta {
+    font-family: var(--sans);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.24em;
+    color: var(--muted);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.2rem;
+    flex-wrap: wrap;
+  }
+
+  .title-block { align-self: center; max-width: 1100px; }
+
+  h1 {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-style: italic;
+    font-size: clamp(3.5rem, 12vw, 12rem);
+    line-height: 0.9;
+    letter-spacing: -0.035em;
+    color: var(--ink);
+  }
+
+  .sub {
+    font-family: var(--serif);
+    font-style: italic;
+    font-weight: 300;
+    font-size: clamp(1rem, 1.4vw, 1.3rem);
+    color: var(--muted);
+    margin-top: 1.6rem;
+    max-width: 52ch;
+    line-height: 1.4;
+  }
+
+  button {
+    font-family: var(--sans);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.24em;
+    padding: 1rem 1.6rem;
+    background: var(--ink);
+    color: var(--bg);
+    transition: background 200ms ease;
+  }
+  button:hover { background: var(--accent); }
+
+  .hint {
+    font-family: var(--sans);
+    font-size: 0.7rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+
+  .cover-nav {
+    display: flex;
+    gap: 0.9rem;
+    font-family: var(--sans);
+    font-size: 0.72rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--muted);
+  }
+
+  .cover-nav :global(a) {
+    border-bottom: 1px solid transparent;
+    transition: color 160ms ease, border-color 160ms ease;
+  }
+  .cover-nav :global(a:hover) {
+    color: var(--ink);
+    border-bottom-color: var(--ink);
+  }
+</style>

--- a/templates/structure/chaptered/src/routes/[slug]/+page.svelte
+++ b/templates/structure/chaptered/src/routes/[slug]/+page.svelte
@@ -1,0 +1,734 @@
+<script>
+  import { goto, afterNavigate } from '$app/navigation';
+  import { base } from '$app/paths';
+  import {
+    next, prev, flat, chapters,
+    chapterOf, nextChapter, prevChapter,
+    isFirstOfChapter, isLastOfChapter, positionInChapter
+  } from '$lib/outline.js';
+  import { createPager } from 'sveltekitbook/gestures';
+  import { md } from 'sveltekitbook/md';
+  import Giscus from 'sveltekitbook/Giscus.svelte';
+  import { TITLE, GISCUS } from '$lib/config.js';
+  {{glossaryImport}}
+
+  let { data } = $props();
+  let section = $derived(data.section);
+  let nextSection = $derived(next(section.num));
+  let prevSection = $derived(prev(section.num));
+  let chapter = $derived(chapterOf(section.num));
+  let nextCh = $derived(nextChapter(section.num));
+  let prevCh = $derived(prevChapter(section.num));
+  let chapterPos = $derived(positionInChapter(section.num));
+  let firstOfChapter = $derived(isFirstOfChapter(section.num));
+  let lastOfChapter = $derived(isLastOfChapter(section.num));
+  let position = $derived(section.orderIndex + 1);
+  let total = flat.length;
+
+  let dragOffset = $state(0);
+  let dragging = $derived(dragOffset !== 0);
+  let bodyEl = $state();
+
+  afterNavigate(() => {
+    bodyEl?.scrollTo({ top: 0, behavior: 'instant' });
+  });
+
+  const pager = createPager({
+    onNext: () => {
+      if (nextSection) goto(base + '/' + nextSection.num);
+    },
+    onPrev: () => {
+      if (prevSection) goto(base + '/' + prevSection.num);
+      else goto(base + '/');
+    },
+    setOffset: (v) => {
+      dragOffset = v;
+    }
+  });
+
+  function key(e) {
+    if (e.key === 'ArrowRight') {
+      e.preventDefault();
+      if (nextSection) goto(base + '/' + nextSection.num);
+    } else if (e.key === 'ArrowLeft') {
+      e.preventDefault();
+      if (prevSection) goto(base + '/' + prevSection.num);
+      else goto(base + '/');
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      bodyEl?.scrollBy({ top: 180, behavior: 'smooth' });
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      bodyEl?.scrollBy({ top: -180, behavior: 'smooth' });
+    } else if (e.key === ' ' || e.key === 'PageDown') {
+      e.preventDefault();
+      bodyEl?.scrollBy({ top: bodyEl.clientHeight * 0.85, behavior: 'smooth' });
+    } else if (e.key === 'PageUp') {
+      e.preventDefault();
+      bodyEl?.scrollBy({ top: -bodyEl.clientHeight * 0.85, behavior: 'smooth' });
+    } else if (e.key === '[') {
+      e.preventDefault();
+      if (prevCh) goto(base + '/' + prevCh.sections[0].num);
+    } else if (e.key === ']') {
+      e.preventDefault();
+      if (nextCh) goto(base + '/' + nextCh.sections[0].num);
+    } else if (e.key === 'Escape') {
+      goto(base + '/');
+    }
+  }
+
+  let hintProgress = $derived(Math.min(1, Math.abs(dragOffset) / 70));
+  let mdOpts = $derived({{mdOpts}});
+  let chRoman = $derived(romanize(chapter?.num));
+
+  function romanize(n) {
+    if (!n) return '';
+    const r = ['', 'I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX', 'X',
+               'XI', 'XII', 'XIII', 'XIV', 'XV', 'XVI', 'XVII', 'XVIII', 'XIX', 'XX'];
+    return r[n] || String(n);
+  }
+</script>
+
+<svelte:window onkeydown={key} />
+
+<main
+  class="page"
+  class:dragging
+  onwheel={pager.onWheel}
+  ontouchstart={pager.onTouchStart}
+  ontouchmove={pager.onTouchMove}
+  ontouchend={pager.onTouchEnd}
+  ontouchcancel={pager.onTouchCancel}
+  style:transform="translateX({dragOffset}px)"
+>
+  <header class="top">
+    <a class="mark vt-title" href="{base}/">{TITLE}</a>
+    <nav class="top-nav">
+      {{navLinks}}
+    </nav>
+  </header>
+
+  {#if chapter}
+    <div class="chapter-rail">
+      <div class="chapter-meta">
+        {#if prevCh}
+          <a class="ch-jump" href="{base}/{prevCh.sections[0].num}" title="Previous chapter ({prevCh.title})">
+            <span class="ch-jump-arrow">←</span>
+            <span class="ch-jump-label">Ch {romanize(prevCh.num)}</span>
+          </a>
+        {:else}
+          <span class="ch-jump disabled"><span class="ch-jump-arrow">←</span></span>
+        {/if}
+
+        <div class="ch-current">
+          <span class="ch-num">Chapter {romanize(chapter.num)}</span>
+          <span class="ch-title">{chapter.title}</span>
+        </div>
+
+        {#if nextCh}
+          <a class="ch-jump right" href="{base}/{nextCh.sections[0].num}" title="Next chapter ({nextCh.title})">
+            <span class="ch-jump-label">Ch {romanize(nextCh.num)}</span>
+            <span class="ch-jump-arrow">→</span>
+          </a>
+        {:else}
+          <span class="ch-jump right disabled"><span class="ch-jump-arrow">→</span></span>
+        {/if}
+      </div>
+
+      <ol class="ch-dots" aria-label="Sections in this chapter">
+        {#each chapter.sections as s (s.num)}
+          <li>
+            <a
+              class="dot"
+              class:active={s.num === section.num}
+              href="{base}/{s.num}"
+              title="{s.title}"
+              aria-current={s.num === section.num ? 'page' : undefined}
+            >
+              <span class="sr">{s.num} — {s.title}</span>
+            </a>
+          </li>
+        {/each}
+      </ol>
+    </div>
+  {/if}
+
+  <div class="body" bind:this={bodyEl}>
+    {#if firstOfChapter && chapter?.intro}
+      <aside class="ch-intro">
+        <div class="ch-intro-label">Chapter {romanize(chapter.num)}</div>
+        <h2 class="ch-intro-title">{chapter.title}</h2>
+        <p class="ch-intro-body">{@html md(chapter.intro, mdOpts)}</p>
+      </aside>
+    {/if}
+
+    <div class="number">{section.num}</div>
+
+    <h1 class="title">{section.title}</h1>
+
+    {#if section.gesture}
+      <p class="gesture">{@html md(section.gesture, mdOpts)}</p>
+    {/if}
+
+    {#if section.body}
+      <p class="body-text">{@html md(section.body, mdOpts)}</p>
+    {/if}
+
+    {#if section.steps?.length}
+      <ol class="steps">
+        {#each section.steps as step, i (i)}
+          <li class="step">
+            <div class="step-marker" aria-hidden="true">{String(i + 1).padStart(2, '0')}</div>
+            <div class="step-prose">{@html md(step.prose, mdOpts)}</div>
+            <pre class="step-code"><code class="lang-{step.lang || 'text'}">{step.code}</code></pre>
+          </li>
+        {/each}
+      </ol>
+    {/if}
+
+    {#if section.citation || section.link}
+      <footer class="source">
+        {#if section.citation}
+          <span class="cite">{@html md(section.citation, mdOpts)}</span>
+        {/if}
+        {#if section.link}
+          <a class="source-link" href={section.link} target="_blank" rel="noopener noreferrer">
+            Source →
+          </a>
+        {/if}
+      </footer>
+    {/if}
+
+    {#if section.eli5}
+      <aside class="eli5">
+        <div class="eli5-label">In plain terms</div>
+        <p class="eli5-body">{@html md(section.eli5, mdOpts)}</p>
+      </aside>
+    {/if}
+
+    {#if lastOfChapter && nextCh}
+      <aside class="ch-next">
+        <div class="ch-next-label">End of Chapter {romanize(chapter.num)}</div>
+        <a class="ch-next-link" href="{base}/{nextCh.sections[0].num}">
+          <span class="ch-next-num">Chapter {romanize(nextCh.num)}</span>
+          <span class="ch-next-title">{nextCh.title}</span>
+          <span class="ch-next-arrow">→</span>
+        </a>
+      </aside>
+    {/if}
+
+    <Giscus term={section.num} mode="light" {...GISCUS} />
+  </div>
+
+  <footer class="bottom">
+    <div class="nav">
+      {#if prevSection}
+        <a href="{base}/{prevSection.num}" class="nav-link">
+          <span class="arrow">←</span>
+          <span class="nav-meta">
+            <span class="nav-num">{prevSection.num}</span>
+            <span class="nav-title">{prevSection.title}</span>
+          </span>
+        </a>
+      {:else}
+        <a href="{base}/" class="nav-link">
+          <span class="arrow">←</span>
+          <span class="nav-meta"><span class="nav-num">Cover</span></span>
+        </a>
+      {/if}
+
+      <div class="progress">
+        {#if chapterPos}
+          <span class="ch-progress">{chapterPos.index + 1}/{chapterPos.total}</span>
+          <span class="divider">·</span>
+        {/if}
+        <span>{position}</span><span class="divider">/</span><span>{total}</span>
+      </div>
+
+      {#if nextSection}
+        <a href="{base}/{nextSection.num}" class="nav-link right">
+          <span class="nav-meta">
+            <span class="nav-num">{nextSection.num}</span>
+            <span class="nav-title">{nextSection.title}</span>
+          </span>
+          <span class="arrow">→</span>
+        </a>
+      {:else}
+        <span class="nav-link right disabled">
+          <span class="nav-meta"><span class="nav-num">End</span></span>
+        </span>
+      {/if}
+    </div>
+
+    <div class="drag-hint" style:opacity={hintProgress}>
+      <span class="bar" style:transform="scaleX({hintProgress})"></span>
+    </div>
+  </footer>
+</main>
+
+<style>
+  .page {
+    height: 100vh;
+    height: 100dvh;
+    padding: 3vw 5vw;
+    display: grid;
+    grid-template-rows: auto auto minmax(0, 1fr) auto;
+    gap: 1.5vw;
+    transition: transform 320ms cubic-bezier(0.2, 0.9, 0.3, 1);
+    touch-action: pan-y;
+    will-change: transform;
+    overflow: hidden;
+  }
+  .page.dragging { transition: none; }
+
+  .top {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-family: var(--sans);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.24em;
+    color: var(--muted);
+  }
+
+  .mark {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 1rem;
+    letter-spacing: 0;
+    text-transform: none;
+    color: var(--ink);
+  }
+
+  .top-nav { display: flex; gap: 0.9rem; }
+  .top-nav :global(a) {
+    border-bottom: 1px solid transparent;
+    transition: border-color 160ms ease, color 160ms ease;
+  }
+  .top-nav :global(a:hover) { color: var(--ink); border-bottom-color: var(--ink); }
+
+  .chapter-rail {
+    border-top: 1px solid var(--rule);
+    border-bottom: 1px solid var(--rule);
+    padding: 0.7rem 0;
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .chapter-meta {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+    align-items: baseline;
+    gap: 1rem;
+  }
+
+  .ch-jump {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 0.4rem;
+    font-family: var(--sans);
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    color: var(--muted);
+    transition: color 160ms ease;
+  }
+  .ch-jump:hover { color: var(--ink); }
+  .ch-jump.disabled { opacity: 0.25; }
+  .ch-jump.right { justify-self: end; }
+  .ch-jump-arrow { font-family: var(--serif); font-size: 0.95rem; letter-spacing: 0; }
+
+  .ch-current {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  .ch-num {
+    font-family: var(--sans);
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.32em;
+    color: var(--muted);
+  }
+  .ch-title {
+    font-family: var(--serif);
+    font-style: italic;
+    font-weight: 300;
+    font-size: 1.05rem;
+    color: var(--ink);
+    margin-top: 0.15rem;
+  }
+
+  .ch-dots {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+  }
+  .ch-dots .dot {
+    display: block;
+    width: 1.4rem;
+    height: 4px;
+    background: var(--rule);
+    transition: background 160ms ease, transform 160ms ease;
+  }
+  .ch-dots .dot:hover { background: var(--muted); }
+  .ch-dots .dot.active {
+    background: var(--accent);
+    transform: scaleY(1.6);
+  }
+  .sr {
+    position: absolute;
+    width: 1px; height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  .body {
+    display: grid;
+    grid-template-columns: minmax(180px, 1fr) 3fr;
+    gap: 4vw;
+    align-items: start;
+    padding: 1.5vw 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .ch-intro {
+    grid-column: 1 / -1;
+    border-left: 2px solid var(--accent);
+    padding: 0.8rem 1.4rem;
+    background: rgba(20, 17, 13, 0.03);
+    margin-bottom: 0.5rem;
+  }
+  .ch-intro-label {
+    font-family: var(--sans);
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.3em;
+    color: var(--accent);
+  }
+  .ch-intro-title {
+    font-family: var(--serif);
+    font-style: italic;
+    font-weight: 300;
+    font-size: clamp(1.4rem, 2.2vw, 1.8rem);
+    color: var(--ink);
+    margin: 0.3rem 0 0.7rem;
+  }
+  .ch-intro-body {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: 1rem;
+    line-height: 1.5;
+    color: var(--ink);
+    max-width: 60ch;
+  }
+
+  .number {
+    grid-column: 1;
+    font-family: var(--serif);
+    font-weight: 200;
+    font-size: clamp(4rem, 9vw, 9rem);
+    line-height: 0.9;
+    letter-spacing: -0.03em;
+    color: var(--muted);
+    font-variant-numeric: lining-nums tabular-nums;
+    margin-top: 0.5rem;
+  }
+
+  .title {
+    grid-column: 2;
+    font-family: var(--serif);
+    font-weight: 300;
+    font-style: italic;
+    font-size: clamp(2.4rem, 6vw, 6rem);
+    line-height: 0.97;
+    letter-spacing: -0.025em;
+    color: var(--ink);
+    max-width: 18ch;
+  }
+
+  .gesture {
+    grid-column: 2;
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: clamp(1.1rem, 1.5vw, 1.4rem);
+    line-height: 1.4;
+    color: var(--ink);
+    max-width: 44ch;
+    margin-top: 1.6rem;
+    border-left: 2px solid var(--accent);
+    padding-left: 1.3rem;
+  }
+
+  .body-text {
+    grid-column: 2;
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: clamp(0.95rem, 1.05vw, 1.05rem);
+    line-height: 1.55;
+    color: var(--ink);
+    max-width: 56ch;
+    margin-top: 1.2rem;
+    padding-left: 1.3rem;
+  }
+
+  .steps {
+    grid-column: 2;
+    list-style: none;
+    margin: 1.6rem 0 0;
+    padding: 0;
+    max-width: 64ch;
+    display: flex;
+    flex-direction: column;
+    gap: 1.4rem;
+  }
+  .step {
+    display: grid;
+    grid-template-columns: 2.4rem 1fr;
+    gap: 0.8rem 1rem;
+    align-items: start;
+    padding-left: 1.3rem;
+    border-left: 2px solid var(--rule);
+  }
+  .step:hover { border-left-color: var(--accent); }
+  .step-marker {
+    grid-column: 1;
+    grid-row: 1;
+    font-family: var(--sans);
+    font-size: 0.62rem;
+    letter-spacing: 0.2em;
+    color: var(--muted);
+    margin-top: 0.3rem;
+  }
+  .step-prose {
+    grid-column: 2;
+    grid-row: 1;
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: 1rem;
+    line-height: 1.55;
+    color: var(--ink);
+  }
+  .step-prose :global(p) { margin: 0; }
+  .step-prose :global(code) {
+    font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+    font-size: 0.88em;
+    background: rgba(20, 17, 13, 0.06);
+    padding: 0.05rem 0.3rem;
+    border-radius: 2px;
+  }
+  .step-code {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    margin: 0.2rem 0 0;
+    padding: 0.9rem 1.1rem;
+    background: rgba(20, 17, 13, 0.04);
+    border-left: 2px solid var(--accent);
+    font-family: var(--mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+    font-size: 0.85rem;
+    line-height: 1.55;
+    color: var(--ink);
+    overflow-x: auto;
+    white-space: pre;
+    -webkit-overflow-scrolling: touch;
+  }
+  .step-code code {
+    font-family: inherit;
+    background: transparent;
+    padding: 0;
+  }
+
+  .source {
+    grid-column: 2;
+    margin-top: 1.4rem;
+    padding: 0.8rem 0 0 1.3rem;
+    border-top: 1px dotted var(--rule);
+    max-width: 56ch;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+  }
+
+  .cite {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 0.82rem;
+    color: var(--muted);
+    line-height: 1.4;
+  }
+
+  .source-link {
+    font-family: var(--sans);
+    font-size: 0.68rem;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    color: var(--accent);
+    border-bottom: 1px solid transparent;
+    white-space: nowrap;
+    transition: border-color 180ms ease;
+  }
+  .source-link:hover { border-color: var(--accent); }
+
+  .eli5 {
+    grid-column: 2;
+    margin-top: 2rem;
+    max-width: 56ch;
+    padding: 1.2rem 1.3rem;
+    border-left: 2px solid var(--accent);
+    background: rgba(20, 17, 13, 0.04);
+  }
+  .eli5-label {
+    font-family: var(--sans);
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.3em;
+    color: var(--accent);
+    margin-bottom: 0.6rem;
+  }
+  .eli5-body {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: clamp(0.95rem, 1.05vw, 1.05rem);
+    line-height: 1.55;
+    color: var(--ink);
+  }
+
+  .ch-next {
+    grid-column: 2;
+    margin-top: 2.4rem;
+    padding: 1.2rem 1.3rem;
+    border: 1px solid var(--rule);
+    max-width: 56ch;
+    background: rgba(20, 17, 13, 0.02);
+  }
+  .ch-next-label {
+    font-family: var(--sans);
+    font-size: 0.62rem;
+    text-transform: uppercase;
+    letter-spacing: 0.3em;
+    color: var(--muted);
+    margin-bottom: 0.5rem;
+  }
+  .ch-next-link {
+    display: flex;
+    align-items: baseline;
+    gap: 0.8rem;
+    color: var(--ink);
+    transition: color 160ms ease;
+  }
+  .ch-next-link:hover { color: var(--accent); }
+  .ch-next-num {
+    font-family: var(--sans);
+    font-size: 0.66rem;
+    text-transform: uppercase;
+    letter-spacing: 0.24em;
+    color: var(--muted);
+  }
+  .ch-next-title {
+    font-family: var(--serif);
+    font-style: italic;
+    font-weight: 300;
+    font-size: 1.4rem;
+    flex: 1;
+  }
+  .ch-next-arrow { font-family: var(--serif); font-size: 1.4rem; color: var(--accent); }
+
+  .bottom { font-family: var(--sans); }
+
+  .nav {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 2rem;
+    border-top: 1px solid var(--rule);
+    padding-top: 1.2rem;
+    margin-top: 1rem;
+  }
+
+  .nav-link {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    color: var(--muted);
+    transition: color 180ms ease;
+  }
+  .nav-link:hover { color: var(--ink); }
+  .nav-link.disabled { opacity: 0.35; }
+  .nav-link.right { justify-self: end; text-align: right; }
+
+  .arrow { font-family: var(--serif); font-size: 1.4rem; }
+
+  .nav-meta { display: flex; flex-direction: column; gap: 0.15rem; }
+  .nav-num { font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.24em; }
+  .nav-title {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 0.95rem;
+    color: var(--ink);
+  }
+
+  .progress {
+    font-size: 0.72rem;
+    letter-spacing: 0.24em;
+    color: var(--muted);
+    display: flex;
+    gap: 0.4rem;
+    align-items: baseline;
+  }
+  .progress .divider { color: var(--rule); }
+  .ch-progress { color: var(--accent); }
+
+  .drag-hint {
+    position: absolute;
+    left: 0; right: 0; bottom: 0;
+    height: 2px;
+    pointer-events: none;
+    transition: opacity 140ms ease;
+  }
+  .drag-hint .bar {
+    display: block;
+    height: 100%;
+    background: var(--accent);
+    transform-origin: center;
+    transition: transform 80ms linear;
+  }
+
+  @media (max-width: 720px) {
+    .page { padding: 4vw 7vw; }
+    .body {
+      grid-template-columns: 1fr;
+      gap: 2.5vw;
+      padding: 1.5vw 0;
+    }
+    .number, .title, .gesture, .body-text, .source, .eli5, .ch-next, .steps {
+      grid-column: 1;
+      max-width: none;
+    }
+    .step { padding-left: 0.7rem; }
+    .step-code { font-size: 0.78rem; padding: 0.7rem 0.8rem; }
+    .title, .gesture, .body-text, .cite, .eli5-body {
+      overflow-wrap: break-word;
+      word-break: break-word;
+      hyphens: auto;
+    }
+    .number { font-size: clamp(3rem, 12vw, 5rem); margin-top: 0.2rem; }
+    .title { font-size: clamp(1.9rem, 7vw, 3rem); }
+    .gesture { font-size: clamp(1rem, 3.8vw, 1.2rem); padding-left: 0.9rem; }
+    .body-text { padding-left: 0.9rem; }
+    .source { padding-left: 0.9rem; }
+    .nav { gap: 0.8rem; }
+    .ch-dots .dot { width: 1rem; }
+    .chapter-meta { gap: 0.5rem; }
+    .ch-title { font-size: 0.95rem; }
+  }
+</style>

--- a/templates/structure/chaptered/src/routes/contents/+page.svelte
+++ b/templates/structure/chaptered/src/routes/contents/+page.svelte
@@ -1,0 +1,125 @@
+<script>
+  import { base } from '$app/paths';
+  import { chapters, flat } from '$lib/outline.js';
+  import { TITLE } from '$lib/config.js';
+
+  $effect(() => {
+    if (typeof document === 'undefined') return;
+    document.documentElement.setAttribute(
+      'style',
+      '--bg:#ffffff;--ink:#14110d;--muted:rgba(20,17,13,0.56);--rule:rgba(20,17,13,0.16);--accent:#6a6a6a;'
+    );
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'auto';
+    return () => { document.body.style.overflow = prevOverflow; };
+  });
+
+  function romanize(n) {
+    const r = ['', 'I', 'II', 'III', 'IV', 'V', 'VI', 'VII', 'VIII', 'IX', 'X',
+               'XI', 'XII', 'XIII', 'XIV', 'XV', 'XVI', 'XVII', 'XVIII', 'XIX', 'XX'];
+    return r[n] || String(n);
+  }
+</script>
+
+<svelte:head><title>Contents — {TITLE}</title></svelte:head>
+
+<main class="page">
+  <header class="top">
+    <a class="mark" href="{base}/">{TITLE}</a>
+    <nav class="top-nav"><a class="cover-link" href="{base}/">Cover ←</a></nav>
+  </header>
+
+  <div class="intro">
+    <div class="kicker">Contents</div>
+    <h1>{chapters.length} {chapters.length === 1 ? 'chapter' : 'chapters'} · {flat.length} sections</h1>
+  </div>
+
+  <ol class="chapter-list">
+    {#each chapters as ch (ch.id)}
+      <li class="chapter">
+        <header class="chapter-head">
+          <div class="chapter-num">Chapter {romanize(ch.num)}</div>
+          <h2 class="chapter-title">
+            <a href="{base}/{ch.sections[0].num}">{ch.title}</a>
+          </h2>
+          {#if ch.intro}
+            <p class="chapter-intro">{ch.intro}</p>
+          {/if}
+        </header>
+
+        <ul class="entries">
+          {#each ch.sections as e (e.num)}
+            <li>
+              <a class="entry" href="{base}/{e.num}">
+                <span class="entry-num">{e.num}</span>
+                <span class="entry-title">{e.title}</span>
+              </a>
+            </li>
+          {/each}
+        </ul>
+      </li>
+    {/each}
+  </ol>
+</main>
+
+<style>
+  .page {
+    min-height: 100vh; min-height: 100dvh;
+    padding: 4vw 7vw 6vw;
+    display: flex; flex-direction: column; gap: 3vw;
+  }
+
+  .top { display: flex; justify-content: space-between; align-items: center; font-family: var(--sans); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.24em; color: var(--muted); }
+  .mark { font-family: var(--serif); font-style: italic; font-size: 1rem; letter-spacing: 0; text-transform: none; color: var(--ink); }
+  .cover-link { color: var(--muted); transition: color 160ms; }
+  .cover-link:hover { color: var(--ink); }
+
+  .intro { max-width: 1100px; }
+  .kicker { font-family: var(--sans); font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.28em; color: var(--muted); margin-bottom: 1.2rem; }
+  h1 { font-family: var(--serif); font-weight: 300; font-style: italic; font-size: clamp(2.4rem, 6vw, 4.8rem); line-height: 0.98; letter-spacing: -0.025em; color: var(--ink); }
+
+  .chapter-list { list-style: none; margin: 1rem 0 0; padding: 0; display: flex; flex-direction: column; gap: 3rem; }
+
+  .chapter { border-top: 1px solid var(--rule); padding-top: 1.4rem; }
+
+  .chapter-head { margin-bottom: 1rem; }
+  .chapter-num { font-family: var(--sans); font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.3em; color: var(--accent); }
+  .chapter-title {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-style: italic;
+    font-size: clamp(1.6rem, 3vw, 2.4rem);
+    line-height: 1.05;
+    color: var(--ink);
+    margin: 0.4rem 0 0.6rem;
+  }
+  .chapter-title a { color: inherit; border-bottom: 1px solid transparent; transition: border-color 160ms ease; }
+  .chapter-title a:hover { border-bottom-color: var(--ink); }
+  .chapter-intro {
+    font-family: var(--serif);
+    font-weight: 300;
+    font-size: 0.98rem;
+    line-height: 1.5;
+    color: var(--muted);
+    max-width: 60ch;
+    margin: 0;
+  }
+
+  .entries { list-style: none; margin: 0; padding: 0; }
+  .entry {
+    display: grid;
+    grid-template-columns: 3ch minmax(0, 1fr);
+    gap: 1.2rem;
+    align-items: baseline;
+    padding: 0.5rem 0;
+    border-bottom: 1px dotted var(--rule);
+    color: var(--ink);
+  }
+  .entry:hover { background: rgba(20, 17, 13, 0.03); }
+  .entry-num { font-family: var(--sans); font-size: 0.68rem; letter-spacing: 0.18em; color: var(--muted); }
+  .entry-title { font-family: var(--serif); font-style: italic; font-weight: 300; font-size: clamp(0.98rem, 1.15vw, 1.12rem); color: var(--ink); overflow-wrap: break-word; }
+
+  @media (max-width: 720px) {
+    .entry { grid-template-columns: 2.4ch 1fr; }
+  }
+</style>


### PR DESCRIPTION
## Summary
- Adds a `structure: 'flat' | 'chaptered'` dimension to the scaffolder. `flat` is the existing behaviour and stays the default — fully backward compatible. `chaptered` is selected via a new prompt.
- New overlay in `templates/structure/chaptered/` replaces `outline.js`, `[slug]/+page.svelte`, `contents/+page.svelte`, and `+page.svelte` (cover). Page numbers stay linear across the whole book; chapters are derived by grouping consecutive sections that share `chapterId` — no parallel tree to maintain.
- Adds an optional per-section `steps: [{ prose, code, lang }]` field that enforces a prose / code / prose / code rhythm. Use it for code-led explainers.

## What chaptered gets you
- Chapter rail across the top of every section: prev/next chapter jump, chapter title, dotted progress through the chapter's sections.
- `[` and `]` keys jump between chapters; `←`/`→` still walk linearly.
- The first section of each chapter renders the chapter intro above the body. The last section of each chapter renders a "next chapter →" callout above the bottom nav.
- Bottom progress shows `section-in-chapter · section-in-book` (e.g. `3/7 · 11/50`).
- Contents page groups by chapter; each chapter shows its intro + ordered section list.

## Section shape
```js
{
  chapterId: 'first',
  chapterNum: 1,
  chapterTitle: 'A Bad Stack',
  chapterIntro: '...',         // optional; renders above the first section of the chapter
  title: 'Push',
  gesture: '...',
  body: '...',                 // optional, prose-led
  steps: [                     // optional, code-led; mutually compatible with body
    { prose: '...', code: '...', lang: 'rust' },
    { prose: '...', code: '...', lang: 'rust' }
  ],
  link: '...',
  eli5: '...'
}
```

If both `body` and `steps` are present they render in order — body first, then the step rhythm. Most sections will use one or the other.

## Compatibility
- Chaptered is mutually exclusive with `timeline` / `spectrum` continua in this PR. The prompt skips the continuum question when `chaptered` is selected and the scaffolder forces `continuum: 'none'`. A future PR can compose them.
- Existing `flat` users see no change. The new overlay only ships when `structure: 'chaptered'` is requested.

## Test plan
- [x] Smoke-scaffolded into a temp dir with `structure: 'chaptered'` + `rooms: ['contents']`. All expected files present, chaptered overlay wins on collisions.
- [x] Built the resulting SvelteKit project against a real chaptered book (50 sections / 7 chapters, port of *Learn Rust With Entirely Too Many Linked Lists*). All 50 section pages prerender. Spot-checked: chapter rail, chapter intro on first-of-chapter, chapter-position progress in bottom nav, prose/code step rendering on sections that use `steps`.
- [ ] Manual: walk through with arrow keys + `[` / `]` chapter jumps in the dev server.
- [ ] Manual: contents page renders all chapters grouped, intros render under chapter titles.
- [ ] Manual: a section with `steps` shows prose/code pairs in strict order, code blocks scroll horizontally on narrow viewports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)