### PR TITLE
Add Makefile with deploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# Local release tooling. Not shipped in the published tarball
+# (package.json `files` is `["bin", "templates"]`).
+#
+# Usage:
+#   make deploy    # logs in if needed, prompts for 2FA OTP, runs npm publish
+#
+# Run AFTER bumping version + updating CHANGELOG.md + committing + tagging
+# + pushing — see the release notes in CLAUDE.md.
+
+.PHONY: deploy login publish
+
+deploy: login publish
+
+login:
+	@if ! npm whoami >/dev/null 2>&1; then \
+	  echo "Not logged in to npm — running npm login..."; \
+	  npm login; \
+	fi
+	@echo "npm user: $$(npm whoami)"
+
+publish:
+	@read -s -p "npm 2FA OTP (6 digits): " otp; echo; \
+	npm publish --otp=$$otp


### PR DESCRIPTION
## Summary
- \`make deploy\` runs \`npm login\` if not authenticated, then prompts for the 2FA OTP and runs \`npm publish\`.
- Local tooling only — Makefile is not in the published tarball (\`package.json\` \`files\` is \`["bin", "templates"]\`).
- Mirrors the matching \`Makefile\` just landed on \`AndyGauge/sveltekitbook\` so both repos share the same release flow.

## Test plan
- [ ] \`make deploy\` from a clean checkout: skips login when already authenticated, prompts for OTP, publishes.
- [ ] Confirm the Makefile is excluded from the npm tarball: \`npm pack --dry-run\` should not list it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)