### PR TITLE
Render multi-paragraph fields as paragraphs (mdBlock + div wrappers)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,20 @@ Versioning rule of thumb (mirrors `CLAUDE.md`):
   title, page title, and the section's `tldr`.
 
 ### Changed
-- Scaffolded `package.json` now depends on `sveltekitbook ^0.2.0`
-  (required for the `PageMeta.svelte` export).
+- Scaffolded `package.json` now depends on `sveltekitbook ^0.3.0`
+  (required for the `mdBlock` export — see below).
+- All four `[slug]/+page.svelte` templates render multi-paragraph fields
+  (section bodies, ELI5 blocks, chaptered chapter intros) with `mdBlock`
+  inside `<div>` wrappers instead of inline `md` inside `<p>` wrappers.
+  CSS adds `:global(p)` margin rules so paragraphs are spaced.
+
+### Fixed
+- Section bodies, ELI5 blocks, and chapter intros containing blank
+  lines (`\n\n`) now render as separate paragraphs. Previously the
+  templates wrapped these fields in a single `<p>` and called the
+  inline-only `md()` helper — which preserved `\n\n` as whitespace
+  but never produced `<p>` boundaries, so multi-paragraph source
+  rendered as one collapsed wall of text.
 
 ## [0.2.0] — 2026-04-27
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+# Local release tooling. Not shipped in the published tarball
+# (package.json `files` is `["bin", "templates"]`).
+#
+# Usage:
+#   make deploy    # logs in if needed, prompts for 2FA OTP, runs npm publish
+#
+# Run AFTER bumping version + updating CHANGELOG.md + committing + tagging
+# + pushing — see the release notes in CLAUDE.md.
+
+.PHONY: deploy login publish
+
+deploy: login publish
+
+login:
+	@if ! npm whoami >/dev/null 2>&1; then \
+	  echo "Not logged in to npm — running npm login..."; \
+	  npm login; \
+	fi
+	@echo "npm user: $$(npm whoami)"
+
+publish:
+	@read -s -p "npm 2FA OTP (6 digits): " otp; echo; \
+	npm publish --otp=$$otp

--- a/templates/base/package.json
+++ b/templates/base/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "sveltekitbook": "^0.2.0"
+    "sveltekitbook": "^0.3.0"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.10",

--- a/templates/continuum/none/src/routes/[slug]/+page.svelte
+++ b/templates/continuum/none/src/routes/[slug]/+page.svelte
@@ -3,7 +3,7 @@
   import { base } from '$app/paths';
   import { next, prev, flat } from '$lib/outline.js';
   import { createPager } from 'sveltekitbook/gestures';
-  import { md } from 'sveltekitbook/md';
+  import { md, mdBlock } from 'sveltekitbook/md';
   import Giscus from 'sveltekitbook/Giscus.svelte';
   import PageMeta from 'sveltekitbook/PageMeta.svelte';
   import { TITLE, GISCUS, SITE_URL } from '$lib/config.js';
@@ -103,7 +103,7 @@
     {/if}
 
     {#if section.body}
-      <p class="body-text">{@html md(section.body, mdOpts)}</p>
+      <div class="body-text">{@html mdBlock(section.body, mdOpts)}</div>
     {/if}
 
     {#if section.citation || section.link}
@@ -122,7 +122,7 @@
     {#if section.eli5}
       <aside class="eli5">
         <div class="eli5-label">In plain terms</div>
-        <p class="eli5-body">{@html md(section.eli5, mdOpts)}</p>
+        <div class="eli5-body">{@html mdBlock(section.eli5, mdOpts)}</div>
       </aside>
     {/if}
 
@@ -271,6 +271,8 @@
     margin-top: 1.2rem;
     padding-left: 1.3rem;
   }
+  .body-text :global(p) { margin: 0 0 1.05em; }
+  .body-text :global(p:last-child) { margin-bottom: 0; }
 
   .source {
     grid-column: 2;
@@ -330,6 +332,8 @@
     line-height: 1.55;
     color: var(--ink);
   }
+  .eli5-body :global(p) { margin: 0 0 0.9em; }
+  .eli5-body :global(p:last-child) { margin-bottom: 0; }
 
   .bottom { font-family: var(--sans); }
 

--- a/templates/continuum/spectrum/src/routes/[slug]/+page.svelte
+++ b/templates/continuum/spectrum/src/routes/[slug]/+page.svelte
@@ -4,7 +4,7 @@
   import { next, prev, flat, SPECTRUM_LABELS } from '$lib/outline.js';
   import { styleFor, modeFor } from '$lib/palette.js';
   import { createPager } from 'sveltekitbook/gestures';
-  import { md } from 'sveltekitbook/md';
+  import { md, mdBlock } from 'sveltekitbook/md';
   import Giscus from 'sveltekitbook/Giscus.svelte';
   import PageMeta from 'sveltekitbook/PageMeta.svelte';
   import Spectrum from '$lib/Spectrum.svelte';
@@ -101,7 +101,7 @@
     {/if}
 
     {#if section.body}
-      <p class="body-text">{@html md(section.body, mdOpts)}</p>
+      <div class="body-text">{@html mdBlock(section.body, mdOpts)}</div>
     {/if}
 
     {#if section.citation || section.link}
@@ -118,7 +118,7 @@
     {#if section.eli5}
       <aside class="eli5">
         <div class="eli5-label">In plain terms</div>
-        <p class="eli5-body">{@html md(section.eli5, mdOpts)}</p>
+        <div class="eli5-body">{@html mdBlock(section.eli5, mdOpts)}</div>
       </aside>
     {/if}
 
@@ -207,6 +207,8 @@
   .title { grid-column: 2; font-family: var(--serif); font-weight: 300; font-style: italic; font-size: clamp(2.4rem, 6vw, 6rem); line-height: 0.97; letter-spacing: -0.025em; color: var(--ink); max-width: 18ch; }
   .gesture { grid-column: 2; font-family: var(--serif); font-weight: 300; font-size: clamp(1.1rem, 1.5vw, 1.4rem); line-height: 1.4; color: var(--ink); max-width: 44ch; margin-top: 1.6rem; border-left: 2px solid var(--accent); padding-left: 1.3rem; }
   .body-text { grid-column: 2; font-family: var(--serif); font-weight: 300; font-size: clamp(0.95rem, 1.05vw, 1.05rem); line-height: 1.55; color: var(--ink); max-width: 56ch; margin-top: 1.2rem; padding-left: 1.3rem; }
+  .body-text :global(p) { margin: 0 0 1.05em; }
+  .body-text :global(p:last-child) { margin-bottom: 0; }
 
   .source { grid-column: 2; margin-top: 1.4rem; padding: 0.8rem 0 0 1.3rem; border-top: 1px dotted var(--rule); max-width: 56ch; display: flex; justify-content: space-between; align-items: baseline; gap: 1.5rem; flex-wrap: wrap; }
   .cite { font-family: var(--serif); font-style: italic; font-size: 0.82rem; color: var(--muted); line-height: 1.4; }
@@ -218,6 +220,8 @@
   .page[data-mode='dark']  .eli5 { background: rgba(244, 239, 227, 0.06); }
   .eli5-label { font-family: var(--sans); font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.3em; color: var(--accent); margin-bottom: 0.6rem; }
   .eli5-body { font-family: var(--serif); font-weight: 300; font-size: clamp(0.95rem, 1.05vw, 1.05rem); line-height: 1.55; color: var(--ink); }
+  .eli5-body :global(p) { margin: 0 0 0.9em; }
+  .eli5-body :global(p:last-child) { margin-bottom: 0; }
 
   .bottom { font-family: var(--sans); }
   .nav { display: grid; grid-template-columns: 1fr auto 1fr; align-items: center; gap: 2rem; border-top: 1px solid var(--rule); padding-top: 1.2rem; margin-top: 1rem; }

--- a/templates/continuum/timeline/src/routes/[slug]/+page.svelte
+++ b/templates/continuum/timeline/src/routes/[slug]/+page.svelte
@@ -3,7 +3,7 @@
   import { base } from '$app/paths';
   import { next, prev, flat } from '$lib/outline.js';
   import { createPager } from 'sveltekitbook/gestures';
-  import { md } from 'sveltekitbook/md';
+  import { md, mdBlock } from 'sveltekitbook/md';
   import Giscus from 'sveltekitbook/Giscus.svelte';
   import PageMeta from 'sveltekitbook/PageMeta.svelte';
   import Timeline from '$lib/Timeline.svelte';
@@ -87,7 +87,7 @@
     {/if}
 
     {#if section.body}
-      <p class="body-text">{@html md(section.body, mdOpts)}</p>
+      <div class="body-text">{@html mdBlock(section.body, mdOpts)}</div>
     {/if}
 
     {#if section.citation || section.link}
@@ -104,7 +104,7 @@
     {#if section.eli5}
       <aside class="eli5">
         <div class="eli5-label">In plain terms</div>
-        <p class="eli5-body">{@html md(section.eli5, mdOpts)}</p>
+        <div class="eli5-body">{@html mdBlock(section.eli5, mdOpts)}</div>
       </aside>
     {/if}
 
@@ -257,6 +257,8 @@
     margin-top: 1.2rem;
     padding-left: 1.3rem;
   }
+  .body-text :global(p) { margin: 0 0 1.05em; }
+  .body-text :global(p:last-child) { margin-bottom: 0; }
 
   .source {
     grid-column: 2;
@@ -302,6 +304,8 @@
     margin-bottom: 0.6rem;
   }
   .eli5-body { font-family: var(--serif); font-weight: 300; font-size: clamp(0.95rem, 1.05vw, 1.05rem); line-height: 1.55; color: var(--ink); }
+  .eli5-body :global(p) { margin: 0 0 0.9em; }
+  .eli5-body :global(p:last-child) { margin-bottom: 0; }
 
   .bottom { font-family: var(--sans); }
 

--- a/templates/structure/chaptered/src/routes/[slug]/+page.svelte
+++ b/templates/structure/chaptered/src/routes/[slug]/+page.svelte
@@ -7,7 +7,7 @@
     isFirstOfChapter, isLastOfChapter, positionInChapter
   } from '$lib/outline.js';
   import { createPager } from 'sveltekitbook/gestures';
-  import { md } from 'sveltekitbook/md';
+  import { md, mdBlock } from 'sveltekitbook/md';
   import Giscus from 'sveltekitbook/Giscus.svelte';
   import PageMeta from 'sveltekitbook/PageMeta.svelte';
   import { TITLE, GISCUS, SITE_URL } from '$lib/config.js';
@@ -167,7 +167,7 @@
       <aside class="ch-intro">
         <div class="ch-intro-label">Chapter {romanize(chapter.num)}</div>
         <h2 class="ch-intro-title">{chapter.title}</h2>
-        <p class="ch-intro-body">{@html md(chapter.intro, mdOpts)}</p>
+        <div class="ch-intro-body">{@html mdBlock(chapter.intro, mdOpts)}</div>
       </aside>
     {/if}
 
@@ -180,7 +180,7 @@
     {/if}
 
     {#if section.body}
-      <p class="body-text">{@html md(section.body, mdOpts)}</p>
+      <div class="body-text">{@html mdBlock(section.body, mdOpts)}</div>
     {/if}
 
     {#if section.steps?.length}
@@ -211,7 +211,7 @@
     {#if section.eli5}
       <aside class="eli5">
         <div class="eli5-label">In plain terms</div>
-        <p class="eli5-body">{@html md(section.eli5, mdOpts)}</p>
+        <div class="eli5-body">{@html mdBlock(section.eli5, mdOpts)}</div>
       </aside>
     {/if}
 
@@ -439,6 +439,8 @@
     color: var(--ink);
     max-width: 60ch;
   }
+  .ch-intro-body :global(p) { margin: 0 0 0.9em; }
+  .ch-intro-body :global(p:last-child) { margin-bottom: 0; }
 
   .number {
     grid-column: 1;
@@ -488,6 +490,8 @@
     margin-top: 1.2rem;
     padding-left: 1.3rem;
   }
+  .body-text :global(p) { margin: 0 0 1.05em; }
+  .body-text :global(p:last-child) { margin-bottom: 0; }
 
   .steps {
     grid-column: 2;
@@ -610,6 +614,8 @@
     line-height: 1.55;
     color: var(--ink);
   }
+  .eli5-body :global(p) { margin: 0 0 0.9em; }
+  .eli5-body :global(p:last-child) { margin-bottom: 0; }
 
   .ch-next {
     grid-column: 2;


### PR DESCRIPTION
## Summary
- All four `[slug]/+page.svelte` templates (chaptered, timeline, spectrum, none) now render section bodies, ELI5 blocks, and (in chaptered) chapter intros with `mdBlock` inside `<div>` wrappers instead of inline `md` inside `<p>` wrappers.
- CSS adds `:global(p)` margin rules so paragraphs are spaced properly (1.05em for body, 0.9em for eli5/intro).
- Bumps scaffolded `package.json` to depend on `sveltekitbook ^0.3.0` (which adds the `mdBlock` export).

## Why
The previous templates wrapped multi-paragraph fields in a single `<p class="body-text">` and called the inline-only `md()` helper inside. `md()` is inline-only by design — it does not turn `\n\n` into `<p>` tags — so any field with multi-paragraph source rendered as one collapsed wall of text. Authors writing real prose with paragraph breaks could not get them to render.

`mdBlock` (added in `sveltekitbook` PR #4 / 0.3.0) splits trusted markdown text on blank lines and emits one `<p>` per paragraph with `md()` applied for inline transforms. The consumer pattern is: render the result inside a `<div>` wrapper, never `<p>`. This PR migrates all four scaffold templates to that pattern so every new book gets paragraph rendering for free.

## Existing books
Existing scaffolded books will not auto-receive the fix — they own their `[slug]/+page.svelte` after scaffolding. Authors of existing books can adopt the fix by:
1. Updating `sveltekitbook` to `^0.3.0`.
2. In `[slug]/+page.svelte`, swapping `import { md }` → `import { md, mdBlock }`.
3. Replacing `<p class="body-text">{@html md(section.body, mdOpts)}</p>` with `<div class="body-text">{@html mdBlock(section.body, mdOpts)}</div>` (and same for `eli5-body`, `ch-intro-body`).
4. Adding `.body-text :global(p) { margin: 0 0 1.05em; } .body-text :global(p:last-child) { margin-bottom: 0; }` and matching CSS for `eli5-body` (0.9em) and `ch-intro-body` (0.9em).

## Test plan
- [x] All four templates verified to import `mdBlock`, use `<div>` wrappers, and call `mdBlock` on the relevant fields.
- [ ] Reviewer: scaffold one of each variant locally and confirm a multi-paragraph body renders with proper spacing.
- [ ] Reviewer: confirm `sveltekitbook` PR #4 lands and is published as 0.3.0 before this is merged (or merge both together).

## Depends on
- AndyGauge/sveltekitbook#4 (must land + publish 0.3.0 first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)