### PR TITLE
Rename per-section field gesture → hook, style links in body copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,28 @@ Versioning rule of thumb (mirrors `CLAUDE.md`):
 
 ## [Unreleased]
 
+### Changed
+- **Breaking:** the per-section pull-quote field is now `hook` instead
+  of `gesture`. The old name collided with `sveltekitbook/gestures`,
+  the runtime pager — "gesture" properly belongs to interaction design
+  (swipe, tap, drag), not to a piece of typographic content. The
+  pager module keeps its name; only the data field was renamed.
+  Existing books need to rename `gesture:` → `hook:` in `outline.js`
+  and `[[gesture]]` → `[[hook]]` in any body text. The slug
+  template's CSS class, glossary entry, and example outlines were
+  updated to match.
+
+### Fixed
+- `[slug]/+page.svelte` templates now style links in body copy.
+  External links rendered by `md`/`mdBlock` get a solid accent
+  underline; `[[term]]` glossary links get a dotted underline.
+  Previously the scaffolded `app.css` stripped all link styling
+  globally and per-page CSS only re-added it for nav/source/glossary
+  contexts, so external links inside `body`, `hook`, `eli5`, and
+  `citation` rendered as invisible plain text.
+- Glossary page definitions (`dd`) now also style links the same
+  way — definitions can contain `[label](url)` links too.
+
 ## [0.3.0] — 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Chaptered sections can also use a `steps` array — a strict prose / code / pros
 ```js
 {
   title: 'Push',
-  gesture: '...',
+  hook: '...',
   steps: [
     { prose: 'First we mutate the list...', code: 'fn push(&mut self) { ... }', lang: 'rust' },
     { prose: 'Then we hand back the new head...', code: '...', lang: 'rust' }

--- a/templates/continuum/none/src/lib/outline.js
+++ b/templates/continuum/none/src/lib/outline.js
@@ -7,7 +7,7 @@ const raw = [
     // tldr: one-line summary used for unfurl previews (Slack, iMessage, etc).
     // Optional — pages without it just unfurl with the title only.
     tldr: 'A one-sentence summary that will appear when this page\'s URL is pasted into Slack or iMessage.',
-    gesture: 'Open with the thing you want the reader to remember.',
+    hook: 'Open with the thing you want the reader to remember.',
     body: 'Then explain it. Use **bold** for emphasis, *italic* sparingly. Cite sources. Link out freely.',
     citation: '',
     link: '',
@@ -15,13 +15,13 @@ const raw = [
   },
   {
     title: 'Second section',
-    gesture: 'Every section gets a short hook — one sentence the reader could quote back.',
+    hook: 'Every section gets a short hook — one sentence the reader could quote back.',
     body: 'The body is the argument, the context, the texture. Keep it under 400 words if you can — this is a one-page format.',
     eli5: 'If you can\'t explain it plainly, you haven\'t landed it yet.'
   },
   {
     title: 'Third section',
-    gesture: 'A section without an `eli5` field just omits that block. Every optional field is optional.',
+    hook: 'A section without an `eli5` field just omits that block. Every optional field is optional.',
     body: 'Write only what matters.'
   }
 ];

--- a/templates/continuum/none/src/routes/[slug]/+page.svelte
+++ b/templates/continuum/none/src/routes/[slug]/+page.svelte
@@ -98,8 +98,8 @@
 
     <h1 class="title">{section.title}</h1>
 
-    {#if section.gesture}
-      <p class="gesture">{@html md(section.gesture, mdOpts)}</p>
+    {#if section.hook}
+      <p class="hook">{@html md(section.hook, mdOpts)}</p>
     {/if}
 
     {#if section.body}
@@ -247,7 +247,7 @@
     max-width: 18ch;
   }
 
-  .gesture {
+  .hook {
     grid-column: 2;
     font-family: var(--serif);
     font-weight: 300;
@@ -273,6 +273,28 @@
   }
   .body-text :global(p) { margin: 0 0 1.05em; }
   .body-text :global(p:last-child) { margin-bottom: 0; }
+
+  .body-text :global(a),
+  .hook :global(a),
+  .eli5-body :global(a),
+  .cite :global(a) {
+    color: var(--accent);
+    border-bottom: 1px solid var(--accent);
+    transition: color 160ms ease, border-color 160ms ease;
+  }
+  .body-text :global(a:hover),
+  .hook :global(a:hover),
+  .eli5-body :global(a:hover),
+  .cite :global(a:hover) {
+    color: var(--ink);
+    border-bottom-color: var(--ink);
+  }
+  .body-text :global(a.hw-glossary-link),
+  .hook :global(a.hw-glossary-link),
+  .eli5-body :global(a.hw-glossary-link),
+  .cite :global(a.hw-glossary-link) {
+    border-bottom-style: dotted;
+  }
 
   .source {
     grid-column: 2;
@@ -401,18 +423,18 @@
       gap: 2.5vw;
       padding: 1.5vw 0;
     }
-    .number, .title, .gesture, .body-text, .source, .eli5 {
+    .number, .title, .hook, .body-text, .source, .eli5 {
       grid-column: 1;
       max-width: none;
     }
-    .title, .gesture, .body-text, .cite, .eli5-body {
+    .title, .hook, .body-text, .cite, .eli5-body {
       overflow-wrap: break-word;
       word-break: break-word;
       hyphens: auto;
     }
     .number { font-size: clamp(3rem, 12vw, 5rem); margin-top: 0.2rem; }
     .title { font-size: clamp(1.9rem, 7vw, 3rem); }
-    .gesture { font-size: clamp(1rem, 3.8vw, 1.2rem); padding-left: 0.9rem; }
+    .hook { font-size: clamp(1rem, 3.8vw, 1.2rem); padding-left: 0.9rem; }
     .body-text { padding-left: 0.9rem; }
     .source { padding-left: 0.9rem; }
     .nav { gap: 0.8rem; }

--- a/templates/continuum/spectrum-3/src/lib/outline.js
+++ b/templates/continuum/spectrum-3/src/lib/outline.js
@@ -22,19 +22,19 @@ const raw = [
     // tldr: one-line summary used for unfurl previews (Slack, iMessage, etc).
     // Optional — pages without it just unfurl with the title only.
     tldr: 'A one-sentence summary that will appear when this page\'s URL is pasted into Slack or iMessage.',
-    gesture: 'Short hook — the sentence the reader could quote back.',
+    hook: 'Short hook — the sentence the reader could quote back.',
     body: 'Body paragraph. Use **bold** for emphasis, *italic* sparingly.',
     eli5: 'Plain-language version.'
   },
   {
     title: 'The center',
     spectrum: 0,
-    gesture: 'The neutral stop — mint green. Dark ink on every page.'
+    hook: 'The neutral stop — mint green. Dark ink on every page.'
   },
   {
     title: 'A position on the right',
     spectrum: 2,
-    gesture: 'Another position. The page\'s palette shifts based on where it sits on the spectrum.',
+    hook: 'Another position. The page\'s palette shifts based on where it sits on the spectrum.',
     body: 'Add `invert: true` to any section to flip it into a dark near-black palette — the outlier treatment.'
   }
 ];

--- a/templates/continuum/spectrum-5/src/lib/outline.js
+++ b/templates/continuum/spectrum-5/src/lib/outline.js
@@ -22,19 +22,19 @@ const raw = [
     // tldr: one-line summary used for unfurl previews (Slack, iMessage, etc).
     // Optional — pages without it just unfurl with the title only.
     tldr: 'A one-sentence summary that will appear when this page\'s URL is pasted into Slack or iMessage.',
-    gesture: 'Short hook — the sentence the reader could quote back.',
+    hook: 'Short hook — the sentence the reader could quote back.',
     body: 'Body paragraph. Use **bold** for emphasis, *italic* sparingly.',
     eli5: 'Plain-language version.'
   },
   {
     title: 'The center',
     spectrum: 0,
-    gesture: 'The neutral stop. Dark ink on a warm light palette.'
+    hook: 'The neutral stop. Dark ink on a warm light palette.'
   },
   {
     title: 'Far right',
     spectrum: 4,
-    gesture: 'Another position. Page palette shifts per section.',
+    hook: 'Another position. Page palette shifts per section.',
     body: 'Add `invert: true` to flip a section into the dark outlier palette.'
   }
 ];

--- a/templates/continuum/spectrum/src/routes/[slug]/+page.svelte
+++ b/templates/continuum/spectrum/src/routes/[slug]/+page.svelte
@@ -96,8 +96,8 @@
 
     <h1 class="title">{section.title}</h1>
 
-    {#if section.gesture}
-      <p class="gesture">{@html md(section.gesture, mdOpts)}</p>
+    {#if section.hook}
+      <p class="hook">{@html md(section.hook, mdOpts)}</p>
     {/if}
 
     {#if section.body}
@@ -205,10 +205,32 @@
 
   .number { grid-column: 1; font-family: var(--serif); font-weight: 200; font-size: clamp(4rem, 9vw, 9rem); line-height: 0.9; letter-spacing: -0.03em; color: var(--muted); font-variant-numeric: lining-nums tabular-nums; margin-top: 0.5rem; }
   .title { grid-column: 2; font-family: var(--serif); font-weight: 300; font-style: italic; font-size: clamp(2.4rem, 6vw, 6rem); line-height: 0.97; letter-spacing: -0.025em; color: var(--ink); max-width: 18ch; }
-  .gesture { grid-column: 2; font-family: var(--serif); font-weight: 300; font-size: clamp(1.1rem, 1.5vw, 1.4rem); line-height: 1.4; color: var(--ink); max-width: 44ch; margin-top: 1.6rem; border-left: 2px solid var(--accent); padding-left: 1.3rem; }
+  .hook { grid-column: 2; font-family: var(--serif); font-weight: 300; font-size: clamp(1.1rem, 1.5vw, 1.4rem); line-height: 1.4; color: var(--ink); max-width: 44ch; margin-top: 1.6rem; border-left: 2px solid var(--accent); padding-left: 1.3rem; }
   .body-text { grid-column: 2; font-family: var(--serif); font-weight: 300; font-size: clamp(0.95rem, 1.05vw, 1.05rem); line-height: 1.55; color: var(--ink); max-width: 56ch; margin-top: 1.2rem; padding-left: 1.3rem; }
   .body-text :global(p) { margin: 0 0 1.05em; }
   .body-text :global(p:last-child) { margin-bottom: 0; }
+
+  .body-text :global(a),
+  .hook :global(a),
+  .eli5-body :global(a),
+  .cite :global(a) {
+    color: var(--accent);
+    border-bottom: 1px solid var(--accent);
+    transition: color 160ms ease, border-color 160ms ease;
+  }
+  .body-text :global(a:hover),
+  .hook :global(a:hover),
+  .eli5-body :global(a:hover),
+  .cite :global(a:hover) {
+    color: var(--ink);
+    border-bottom-color: var(--ink);
+  }
+  .body-text :global(a.hw-glossary-link),
+  .hook :global(a.hw-glossary-link),
+  .eli5-body :global(a.hw-glossary-link),
+  .cite :global(a.hw-glossary-link) {
+    border-bottom-style: dotted;
+  }
 
   .source { grid-column: 2; margin-top: 1.4rem; padding: 0.8rem 0 0 1.3rem; border-top: 1px dotted var(--rule); max-width: 56ch; display: flex; justify-content: space-between; align-items: baseline; gap: 1.5rem; flex-wrap: wrap; }
   .cite { font-family: var(--serif); font-style: italic; font-size: 0.82rem; color: var(--muted); line-height: 1.4; }
@@ -242,11 +264,11 @@
   @media (max-width: 720px) {
     .page { padding: 4vw 7vw; }
     .body { grid-template-columns: 1fr; gap: 2.5vw; padding: 1.5vw 0; }
-    .number, .title, .gesture, .body-text, .source, .eli5 { grid-column: 1; max-width: none; }
-    .title, .gesture, .body-text, .cite, .eli5-body { overflow-wrap: break-word; word-break: break-word; hyphens: auto; }
+    .number, .title, .hook, .body-text, .source, .eli5 { grid-column: 1; max-width: none; }
+    .title, .hook, .body-text, .cite, .eli5-body { overflow-wrap: break-word; word-break: break-word; hyphens: auto; }
     .number { font-size: clamp(3rem, 12vw, 5rem); margin-top: 0.2rem; }
     .title { font-size: clamp(1.9rem, 7vw, 3rem); }
-    .gesture { font-size: clamp(1rem, 3.8vw, 1.2rem); padding-left: 0.9rem; }
+    .hook { font-size: clamp(1rem, 3.8vw, 1.2rem); padding-left: 0.9rem; }
     .body-text { padding-left: 0.9rem; }
     .source { padding-left: 0.9rem; }
     .nav { gap: 0.8rem; }

--- a/templates/continuum/timeline/src/lib/outline.js
+++ b/templates/continuum/timeline/src/lib/outline.js
@@ -8,22 +8,22 @@ const raw = [
     // tldr: one-line summary used for unfurl previews (Slack, iMessage, etc).
     // Optional — pages without it just unfurl with the title only.
     tldr: 'A one-sentence summary that will appear when this page\'s URL is pasted into Slack or iMessage.',
-    gesture: 'A one-sentence hook the reader could quote back.',
+    hook: 'A one-sentence hook the reader could quote back.',
     body: 'Body paragraph. Use **bold** for emphasis, *italic* sparingly.',
     eli5: 'Plain-language version of the same point.'
   },
   {
     title: 'A later moment',
     year: 1995,
-    gesture: 'Another turning point — note how the year drives position.',
-    body: 'You can drop `eli5` or `body` on any section. Only `title`, `year`, and `gesture` are recommended.',
+    hook: 'Another turning point — note how the year drives position.',
+    body: 'You can drop `eli5` or `body` on any section. Only `title`, `year`, and `hook` are recommended.',
     citation: 'Source, *Journal*, Year.',
     link: 'https://example.com'
   },
   {
     title: 'The present',
     year: 2024,
-    gesture: 'The timeline widget at the bottom of every page positions you here.'
+    hook: 'The timeline widget at the bottom of every page positions you here.'
   }
 ];
 

--- a/templates/continuum/timeline/src/routes/[slug]/+page.svelte
+++ b/templates/continuum/timeline/src/routes/[slug]/+page.svelte
@@ -82,8 +82,8 @@
 
     <h1 class="title">{section.title}</h1>
 
-    {#if section.gesture}
-      <p class="gesture">{@html md(section.gesture, mdOpts)}</p>
+    {#if section.hook}
+      <p class="hook">{@html md(section.hook, mdOpts)}</p>
     {/if}
 
     {#if section.body}
@@ -233,7 +233,7 @@
     max-width: 18ch;
   }
 
-  .gesture {
+  .hook {
     grid-column: 2;
     font-family: var(--serif);
     font-weight: 300;
@@ -259,6 +259,28 @@
   }
   .body-text :global(p) { margin: 0 0 1.05em; }
   .body-text :global(p:last-child) { margin-bottom: 0; }
+
+  .body-text :global(a),
+  .hook :global(a),
+  .eli5-body :global(a),
+  .cite :global(a) {
+    color: var(--accent);
+    border-bottom: 1px solid var(--accent);
+    transition: color 160ms ease, border-color 160ms ease;
+  }
+  .body-text :global(a:hover),
+  .hook :global(a:hover),
+  .eli5-body :global(a:hover),
+  .cite :global(a:hover) {
+    color: var(--ink);
+    border-bottom-color: var(--ink);
+  }
+  .body-text :global(a.hw-glossary-link),
+  .hook :global(a.hw-glossary-link),
+  .eli5-body :global(a.hw-glossary-link),
+  .cite :global(a.hw-glossary-link) {
+    border-bottom-style: dotted;
+  }
 
   .source {
     grid-column: 2;
@@ -337,11 +359,11 @@
 
   @media (max-width: 720px) {
     .body { grid-template-columns: 1fr; gap: 2.5vw; padding: 1.5vw 0; }
-    .number, .title, .gesture, .body-text, .source, .eli5 { grid-column: 1; max-width: none; }
-    .title, .gesture, .body-text, .cite, .eli5-body { overflow-wrap: break-word; word-break: break-word; hyphens: auto; }
+    .number, .title, .hook, .body-text, .source, .eli5 { grid-column: 1; max-width: none; }
+    .title, .hook, .body-text, .cite, .eli5-body { overflow-wrap: break-word; word-break: break-word; hyphens: auto; }
     .number { font-size: clamp(3rem, 12vw, 5rem); margin-top: 0.2rem; }
     .title { font-size: clamp(1.9rem, 7vw, 3rem); }
-    .gesture { font-size: clamp(1rem, 3.8vw, 1.2rem); padding-left: 0.9rem; }
+    .hook { font-size: clamp(1rem, 3.8vw, 1.2rem); padding-left: 0.9rem; }
     .body-text { padding-left: 0.9rem; }
     .source { padding-left: 0.9rem; }
     .nav { gap: 0.8rem; }

--- a/templates/rooms/book-index/src/routes/book-index/+page.svelte
+++ b/templates/rooms/book-index/src/routes/book-index/+page.svelte
@@ -8,7 +8,7 @@
   // Terms are collected case-insensitively; the display form is the first
   // casing seen.
   const occurrences = new Map();
-  const fields = ['gesture', 'body', 'eli5', 'citation'];
+  const fields = ['hook', 'body', 'eli5', 'citation'];
 
   for (const s of flat) {
     for (const f of fields) {

--- a/templates/rooms/glossary/src/lib/glossary.js
+++ b/templates/rooms/glossary/src/lib/glossary.js
@@ -1,4 +1,4 @@
-// Term definitions. Reference any of these from a section's `body`, `gesture`,
+// Term definitions. Reference any of these from a section's `body`, `hook`,
 // `eli5`, or any other rendered-through-md field as `[[term]]` — it will
 // auto-link to `/glossary#term-slug`. Case-insensitive match.
 //

--- a/templates/rooms/glossary/src/routes/glossary/+page.svelte
+++ b/templates/rooms/glossary/src/routes/glossary/+page.svelte
@@ -105,6 +105,16 @@
   .see a { color: var(--accent); border-bottom: 1px solid transparent; }
   .see a:hover { border-bottom-color: var(--accent); }
 
+  dd :global(a) {
+    color: var(--accent);
+    border-bottom: 1px solid var(--accent);
+    transition: color 160ms ease, border-color 160ms ease;
+  }
+  dd :global(a:hover) {
+    color: var(--ink);
+    border-bottom-color: var(--ink);
+  }
+  dd :global(a.hw-glossary-link),
   .entry :global(a.hw-glossary-link) {
     color: var(--accent);
     border-bottom: 1px dotted var(--accent);

--- a/templates/structure/chaptered/src/lib/outline.js
+++ b/templates/structure/chaptered/src/lib/outline.js
@@ -12,7 +12,7 @@ const raw = [
     // tldr: one-line summary used for unfurl previews (Slack, iMessage, etc).
     // Optional — pages without it just unfurl with the title only.
     tldr: 'A one-sentence summary that will appear when this page\'s URL is pasted into Slack or iMessage.',
-    gesture: 'Open with the thing you want the reader to remember.',
+    hook: 'Open with the thing you want the reader to remember.',
     body: 'Then explain it. Use **bold** for emphasis, *italic* sparingly. Cite sources. Link out freely.',
     eli5: 'Plain-language version of the same point, so a reader with no background can follow.'
   },
@@ -21,7 +21,7 @@ const raw = [
     chapterNum: 1,
     chapterTitle: 'Beginnings',
     title: 'Second section',
-    gesture: 'Each section gets a short hook — one sentence the reader could quote back.',
+    hook: 'Each section gets a short hook — one sentence the reader could quote back.',
     body: 'Sections within a chapter share `chapterId`. Keep them in reading order; chapters are derived from this array, not declared separately.'
   },
   {
@@ -29,7 +29,7 @@ const raw = [
     chapterNum: 1,
     chapterTitle: 'Beginnings',
     title: 'Third section',
-    gesture: 'A section without `eli5` just omits that block. Every optional field is optional.',
+    hook: 'A section without `eli5` just omits that block. Every optional field is optional.',
     body: 'Write only what matters.'
   },
   {
@@ -38,7 +38,7 @@ const raw = [
     chapterTitle: 'Middles',
     chapterIntro: 'A new `chapterId` opens the next chapter. Page numbers keep counting from where the previous chapter left off.',
     title: 'Crossing over',
-    gesture: 'When the reader hits the first section of a new chapter, the chapter intro renders above the section title.',
+    hook: 'When the reader hits the first section of a new chapter, the chapter intro renders above the section title.',
     body: 'Reaching this section, the reader sees a "Chapter 2 — Middles" header and the chapter intro before the section content.'
   },
   {
@@ -46,7 +46,7 @@ const raw = [
     chapterNum: 2,
     chapterTitle: 'Middles',
     title: 'Last section',
-    gesture: 'The bottom nav shows the next chapter when you reach the end of a chapter.',
+    hook: 'The bottom nav shows the next chapter when you reach the end of a chapter.',
     body: 'Use the chapter rail at the top to jump between chapters. Use prev/next at the bottom to walk linearly.'
   },
   {
@@ -54,7 +54,7 @@ const raw = [
     chapterNum: 2,
     chapterTitle: 'Middles',
     title: 'Code-led section',
-    gesture: 'For tutorials and explainers, the `steps` field lets a section alternate prose and code in a strict rhythm.',
+    hook: 'For tutorials and explainers, the `steps` field lets a section alternate prose and code in a strict rhythm.',
     steps: [
       {
         prose: 'A step is one short prose paragraph followed by one code block. Steps render in order, prose-code-prose-code, no other ordering allowed.',

--- a/templates/structure/chaptered/src/routes/[slug]/+page.svelte
+++ b/templates/structure/chaptered/src/routes/[slug]/+page.svelte
@@ -175,8 +175,8 @@
 
     <h1 class="title">{section.title}</h1>
 
-    {#if section.gesture}
-      <p class="gesture">{@html md(section.gesture, mdOpts)}</p>
+    {#if section.hook}
+      <p class="hook">{@html md(section.hook, mdOpts)}</p>
     {/if}
 
     {#if section.body}
@@ -466,7 +466,7 @@
     max-width: 18ch;
   }
 
-  .gesture {
+  .hook {
     grid-column: 2;
     font-family: var(--serif);
     font-weight: 300;
@@ -492,6 +492,34 @@
   }
   .body-text :global(p) { margin: 0 0 1.05em; }
   .body-text :global(p:last-child) { margin-bottom: 0; }
+
+  .body-text :global(a),
+  .hook :global(a),
+  .eli5-body :global(a),
+  .cite :global(a),
+  .ch-intro-body :global(a),
+  .step-prose :global(a) {
+    color: var(--accent);
+    border-bottom: 1px solid var(--accent);
+    transition: color 160ms ease, border-color 160ms ease;
+  }
+  .body-text :global(a:hover),
+  .hook :global(a:hover),
+  .eli5-body :global(a:hover),
+  .cite :global(a:hover),
+  .ch-intro-body :global(a:hover),
+  .step-prose :global(a:hover) {
+    color: var(--ink);
+    border-bottom-color: var(--ink);
+  }
+  .body-text :global(a.hw-glossary-link),
+  .hook :global(a.hw-glossary-link),
+  .eli5-body :global(a.hw-glossary-link),
+  .cite :global(a.hw-glossary-link),
+  .ch-intro-body :global(a.hw-glossary-link),
+  .step-prose :global(a.hw-glossary-link) {
+    border-bottom-style: dotted;
+  }
 
   .steps {
     grid-column: 2;
@@ -724,20 +752,20 @@
       gap: 2.5vw;
       padding: 1.5vw 0;
     }
-    .number, .title, .gesture, .body-text, .source, .eli5, .ch-next, .steps {
+    .number, .title, .hook, .body-text, .source, .eli5, .ch-next, .steps {
       grid-column: 1;
       max-width: none;
     }
     .step { padding-left: 0.7rem; }
     .step-code { font-size: 0.78rem; padding: 0.7rem 0.8rem; }
-    .title, .gesture, .body-text, .cite, .eli5-body {
+    .title, .hook, .body-text, .cite, .eli5-body {
       overflow-wrap: break-word;
       word-break: break-word;
       hyphens: auto;
     }
     .number { font-size: clamp(3rem, 12vw, 5rem); margin-top: 0.2rem; }
     .title { font-size: clamp(1.9rem, 7vw, 3rem); }
-    .gesture { font-size: clamp(1rem, 3.8vw, 1.2rem); padding-left: 0.9rem; }
+    .hook { font-size: clamp(1rem, 3.8vw, 1.2rem); padding-left: 0.9rem; }
     .body-text { padding-left: 0.9rem; }
     .source { padding-left: 0.9rem; }
     .nav { gap: 0.8rem; }


### PR DESCRIPTION
## Summary

- **Breaking rename**: per-section pull-quote field is now `hook` instead of `gesture`. The old name collided with `sveltekitbook/gestures`, the runtime pager — "gesture" properly belongs to interaction design (swipe / drag / tap), not a piece of typographic content. The pager module keeps its name; only the data field was renamed. Touches all five outline.js examples, the four `[slug]/+page.svelte` renderers, glossary template, book-index field list, and README.
- **Link styling fix**: scaffolded `app.css` strips link styling globally, and per-page CSS only re-added it for nav / source / glossary contexts. External links (`[label](url)`) and `[[term]]` glossary links inside body / hook / eli5 / citation / ch-intro-body / step-prose rendered as invisible plain text. Now external links get a solid accent underline and glossary links get a dotted underline; both turn ink-on-hover. Glossary page definitions (`dd`) got the same rules.

## Migration

Existing scaffolded books need to:
- rename `gesture:` → `hook:` in every page object in `outline.js`
- rename `[[gesture]]` → `[[hook]]` anywhere it appears in body text
- rename the `gesture` glossary entry (if present) to `hook` and update any `see: ['gesture', ...]` cross-refs
- rename `class="gesture"` → `class="hook"` and `.gesture` CSS → `.hook` and `section.gesture` → `section.hook` in their `[slug]/+page.svelte`

## Test plan

- [x] `node bin/index.js` for `none`, `chaptered`, and `spectrum` continuum smoke-builds with `npm run build`
- [x] grep confirms zero `\bgesture\b` references remain in `templates/`
- [x] grep confirms `'sveltekitbook/gestures'` runtime imports unchanged
- [ ] visual check: external links are accent-underlined, glossary links dotted

🤖 Generated with [Claude Code](https://claude.com/claude-code)