### PR TITLE
Surface section hook on the contents page

### DIFF
--- a/templates/rooms/contents/src/routes/contents/+page.svelte
+++ b/templates/rooms/contents/src/routes/contents/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import { base } from '$app/paths';
   import { flat } from '$lib/outline.js';
+  import { md } from 'sveltekitbook/md';
   import { TITLE } from '$lib/config.js';
 
   // Reset to a neutral palette + allow the contents page to scroll past the
@@ -36,7 +37,12 @@
       <li>
         <a class="entry" href="{base}/{e.num}">
           <span class="entry-num">{e.num}</span>
-          <span class="entry-title">{e.title}</span>
+          <span class="entry-text">
+            <span class="entry-title">{e.title}</span>
+            {#if e.hook ?? e.gesture}
+              <span class="entry-hook">{@html md(e.hook ?? e.gesture)}</span>
+            {/if}
+          </span>
           {#if e.year !== undefined}<span class="entry-meta">{e.year}</span>{/if}
         </a>
       </li>
@@ -67,14 +73,17 @@
     grid-template-columns: 3ch minmax(0, 1fr) auto;
     gap: 1.2rem;
     align-items: baseline;
-    padding: 0.6rem 0;
+    padding: 1rem 0;
     border-bottom: 1px dotted var(--rule);
     color: var(--ink);
   }
   .entry:hover { background: rgba(20, 17, 13, 0.03); }
 
   .entry-num { font-family: var(--sans); font-size: 0.68rem; letter-spacing: 0.18em; color: var(--muted); }
+  .entry-text { display: flex; flex-direction: column; gap: 0.35rem; min-width: 0; }
   .entry-title { font-family: var(--serif); font-style: italic; font-weight: 300; font-size: clamp(0.98rem, 1.15vw, 1.12rem); color: var(--ink); overflow-wrap: break-word; }
+  .entry-hook { font-family: var(--serif); font-weight: 300; font-size: clamp(0.88rem, 1vw, 0.98rem); line-height: 1.45; color: var(--muted); max-width: 60ch; }
+  .entry-hook :global(code) { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 0.92em; background: rgba(20, 17, 13, 0.06); padding: 0 0.3em; border-radius: 3px; color: var(--ink); }
   .entry-meta { font-family: var(--sans); font-size: 0.68rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); }
 
   @media (max-width: 720px) {

--- a/templates/structure/chaptered/src/routes/contents/+page.svelte
+++ b/templates/structure/chaptered/src/routes/contents/+page.svelte
@@ -1,6 +1,7 @@
 <script>
   import { base } from '$app/paths';
   import { chapters, flat } from '$lib/outline.js';
+  import { md } from 'sveltekitbook/md';
   import { TITLE } from '$lib/config.js';
 
   $effect(() => {
@@ -52,7 +53,12 @@
             <li>
               <a class="entry" href="{base}/{e.num}">
                 <span class="entry-num">{e.num}</span>
-                <span class="entry-title">{e.title}</span>
+                <span class="entry-text">
+                  <span class="entry-title">{e.title}</span>
+                  {#if e.hook ?? e.gesture}
+                    <span class="entry-hook">{@html md(e.hook ?? e.gesture)}</span>
+                  {/if}
+                </span>
               </a>
             </li>
           {/each}
@@ -111,13 +117,16 @@
     grid-template-columns: 3ch minmax(0, 1fr);
     gap: 1.2rem;
     align-items: baseline;
-    padding: 0.5rem 0;
+    padding: 0.9rem 0;
     border-bottom: 1px dotted var(--rule);
     color: var(--ink);
   }
   .entry:hover { background: rgba(20, 17, 13, 0.03); }
   .entry-num { font-family: var(--sans); font-size: 0.68rem; letter-spacing: 0.18em; color: var(--muted); }
+  .entry-text { display: flex; flex-direction: column; gap: 0.3rem; min-width: 0; }
   .entry-title { font-family: var(--serif); font-style: italic; font-weight: 300; font-size: clamp(0.98rem, 1.15vw, 1.12rem); color: var(--ink); overflow-wrap: break-word; }
+  .entry-hook { font-family: var(--serif); font-weight: 300; font-size: clamp(0.86rem, 0.95vw, 0.94rem); line-height: 1.45; color: var(--muted); max-width: 60ch; }
+  .entry-hook :global(code) { font-family: 'JetBrains Mono', ui-monospace, monospace; font-size: 0.92em; background: rgba(20, 17, 13, 0.06); padding: 0 0.3em; border-radius: 3px; color: var(--ink); }
 
   @media (max-width: 720px) {
     .entry { grid-template-columns: 2.4ch 1fr; }


### PR DESCRIPTION
## Summary

Both contents templates — \`templates/rooms/contents\` and the chaptered override at \`templates/structure/chaptered/src/routes/contents\` — now render each section's hook below the title, so the contents page does real work. Hooks pipe through \`md()\` so inline backticks chip out as \`<code>\` (with \`sveltekitbook\` ^0.4.0), bold and inline links work, and \`[[term]]\` glossary refs link.

Backwards-compat: \`e.hook ?? e.gesture\` so existing books scaffolded before the rename still work after pulling updated templates. Independent of #7 — merges cleanly in either order.

## Test plan

- [x] both contents templates updated, layout grid widened from \`0.6rem 0\` to \`1rem 0\` padding so two-line entries breathe
- [x] scoped \`<code>\` styling on \`.entry-hook\` so backticks render as chips even before the rename PR adds global \`code\` CSS to \`app.css\`
- [ ] scaffold \`none\` and \`chaptered\` smoke books and visually verify the contents page

🤖 Generated with [Claude Code](https://claude.com/claude-code)